### PR TITLE
Handle user status updates through standard endpoint

### DIFF
--- a/resources/js/src/pages/dashboard/users/list/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/index.tsx
@@ -101,10 +101,14 @@ export default function List({ users, roles }: Props) {
     const data: Record<string, any> = { _token: csrfToken };
     if (field === 'roles') {
       data.roles = updated.roles;
+      router.patch(route('users.update', id), data, { preserveScroll: true });
+    } else if (field === 'status') {
+      data.status = updated.status;
+      router.patch(route('users.update', id), data, { preserveScroll: true });
     } else {
       data[field] = (updated as any)[field];
+      router.patch(route('users.update', id), data, { preserveScroll: true });
     }
-    router.patch(route('users.update', id), data, { preserveScroll: true });
     setEditing({ id: null, field: null });
   };
 


### PR DESCRIPTION
## Summary
- remove dedicated user-status route and method
- route status edits in user list to the general update action

## Testing
- `npm run build`
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d45678208322a27227af981644fb