### PR TITLE
feat: add global inertia page props

### DIFF
--- a/resources/js/src/hooks/useLang.tsx
+++ b/resources/js/src/hooks/useLang.tsx
@@ -1,12 +1,12 @@
 import { usePage } from '@inertiajs/react';
-import type { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 
 type Replaces = Record<string, string | number>;
 type LangValue = string | { [key: string]: string | LangValue };
 type LangObject = Record<string, LangValue>;
-type AppPageProps = InertiaPageProps & { lang: LangObject };
+
 export function useLang() {
-  const { lang } = usePage<AppPageProps>().props;
+  const { lang } = usePage<PageProps>().props;
 
   function trans(key: string, replaces: Replaces | string = {}): string {
     const raw = getValueFromKey(key);

--- a/resources/js/src/layouts/components/account-drawer.tsx
+++ b/resources/js/src/layouts/components/account-drawer.tsx
@@ -25,6 +25,7 @@ import { Scrollbar } from 'src/components/scrollbar';
 import { AnimateBorder } from 'src/components/animate';
 
 import { usePage } from '@inertiajs/react';
+import type { PageProps } from '@inertiajs/core';
 import { CONFIG } from 'src/global-config';
 
 import { UpgradeBlock } from './nav-upgrade';
@@ -40,17 +41,6 @@ export type AccountDrawerProps = IconButtonProps & {
     icon?: React.ReactNode;
     info?: React.ReactNode;
   }[];
-};
-
-type PageProps = {
-  auth: {
-    user: {
-      name: string;
-      email: string;
-      avatar: string;
-      role?: string;
-    };
-  };
 };
 
 export function AccountDrawer({ data = [], sx, ...other }: AccountDrawerProps) {

--- a/resources/js/src/layouts/components/language-popover.tsx
+++ b/resources/js/src/layouts/components/language-popover.tsx
@@ -12,7 +12,7 @@ import { FlagIcon } from 'src/components/flag-icon';
 import { CustomPopover } from 'src/components/custom-popover';
 import { transitionTap, varHover, varTap } from 'src/components/animate';
 import { router, usePage } from '@inertiajs/react';
-import type { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 // ----------------------------------------------------------------------
 
 export type LanguagePopoverProps = IconButtonProps & {
@@ -23,13 +23,9 @@ export type LanguagePopoverProps = IconButtonProps & {
   }[];
 };
 
-type AppPageProps = InertiaPageProps & {
-  locale: string;
-  csrf_token: string;
-};
 export function LanguagePopover({ data = [], sx, ...other }: LanguagePopoverProps) {
   const { open, anchorEl, onClose, onOpen } = usePopover();
-  const { props } = usePage<AppPageProps>();
+  const { props } = usePage<PageProps>();
   const { locale, csrf_token } = props;
 
   const handleChangeLang = useCallback(

--- a/resources/js/src/layouts/components/nav-upgrade.tsx
+++ b/resources/js/src/layouts/components/nav-upgrade.tsx
@@ -14,20 +14,9 @@ import { CONFIG } from 'src/global-config';
 import { Label } from 'src/components/label';
 
 import { usePage } from '@inertiajs/react';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 
 // ----------------------------------------------------------------------
-
-type PageProps = InertiaPageProps & {
-  auth: {
-    user: {
-      name: string;
-      email: string;
-      avatar: string;
-      role?: string;
-    };
-  };
-};
 
 export function NavUpgrade({ sx, ...other }: BoxProps) {
   const {

--- a/resources/js/src/layouts/dashboard/layout.tsx
+++ b/resources/js/src/layouts/dashboard/layout.tsx
@@ -16,8 +16,6 @@ import { _contacts, _notifications } from 'src/_mock';
 import { Logo } from 'src/components/logo';
 import { useSettingsContext } from 'src/components/settings';
 
-import { usePage } from '@inertiajs/react';
-
 import { NavMobile } from './nav-mobile';
 import { VerticalDivider } from './content';
 import { NavVertical } from './nav-vertical';
@@ -33,6 +31,8 @@ import { ContactsPopover } from '../components/contacts-popover';
 import { WorkspacesPopover } from '../components/workspaces-popover';
 import { useNavData } from '../nav-config-dashboard';
 import { dashboardLayoutVars, dashboardNavColorVars } from './css-vars';
+import { usePage } from '@inertiajs/react';
+import type { PageProps } from '@inertiajs/core';
 import { NotificationsDrawer } from '../components/notifications-drawer';
 
 // ----------------------------------------------------------------------
@@ -47,18 +47,6 @@ export type DashboardLayoutProps = LayoutBaseProps & {
       data?: NavSectionProps['data'];
     };
     main?: MainSectionProps;
-  };
-};
-
-type PageProps = {
-  auth: {
-    user: {
-      name: string;
-      email: string;
-      avatar: string;
-      roles: string[];
-      permissions: string[];
-    };
   };
 };
 

--- a/resources/js/src/lib/authz.ts
+++ b/resources/js/src/lib/authz.ts
@@ -1,13 +1,5 @@
 import { usePage } from '@inertiajs/react';
-
-interface PageProps {
-  auth: {
-    user?: {
-      roles?: string[];
-      permissions?: string[];
-    };
-  };
-}
+import type { PageProps } from '@inertiajs/core';
 
 export function useAuthz() {
   const { props } = usePage<PageProps>();

--- a/resources/js/src/pages/dashboard/permissions/list/index.tsx
+++ b/resources/js/src/pages/dashboard/permissions/list/index.tsx
@@ -31,7 +31,7 @@ import DialogActions from '@mui/material/DialogActions';
 import InputAdornment from '@mui/material/InputAdornment';
 import Checkbox from '@mui/material/Checkbox';
 import MenuItem from '@mui/material/MenuItem';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 
 // ----------------------------------------------------------------------
 
@@ -43,8 +43,6 @@ type Permission = {
   created_at: string;
   roles: Role[];
 };
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 type Props = { permissions: Permission[]; roles: Role[] };
 

--- a/resources/js/src/pages/dashboard/roles/list/index.tsx
+++ b/resources/js/src/pages/dashboard/roles/list/index.tsx
@@ -33,7 +33,7 @@ import InputAdornment from '@mui/material/InputAdornment';
 import Checkbox from '@mui/material/Checkbox';
 import FormControlLabel from '@mui/material/FormControlLabel';
 import Grid from '@mui/material/Grid';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 
 // ----------------------------------------------------------------------
 
@@ -48,8 +48,6 @@ type Role = {
   created_at: string;
   permissions: Permission[];
 };
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 type Props = { roles: Role[]; permissions: Permission[] };
 

--- a/resources/js/src/pages/dashboard/users/create/components/create-user-form/index.tsx
+++ b/resources/js/src/pages/dashboard/users/create/components/create-user-form/index.tsx
@@ -14,15 +14,13 @@ import { Field, Form } from 'src/components/hook-form';
 import { toast } from 'src/components/snackbar';
 import { useLang } from 'src/hooks/useLang';
 import { paths } from 'src/routes/paths';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 import { useBoolean } from 'minimal-shared/hooks';
 import { Iconify } from '@/components/iconify';
 
 // ----------------------------------------------------------------------
 
 type Role = { id: number; name: string };
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 type FormValues = {
   name: string;

--- a/resources/js/src/pages/dashboard/users/edit/components/edit-password-user-form/index.tsx
+++ b/resources/js/src/pages/dashboard/users/edit/components/edit-password-user-form/index.tsx
@@ -11,15 +11,13 @@ import { IconButton, InputAdornment } from '@mui/material';
 import { Field, Form } from 'src/components/hook-form';
 import { toast } from 'src/components/snackbar';
 import { useLang } from 'src/hooks/useLang';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 import { useBoolean } from 'minimal-shared/hooks';
 import { Iconify } from '@/components/iconify';
 
 // ----------------------------------------------------------------------
 
 type User = { id: number };
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 type FormValues = {
   current_password: string;

--- a/resources/js/src/pages/dashboard/users/edit/components/edit-user-form/index.tsx
+++ b/resources/js/src/pages/dashboard/users/edit/components/edit-user-form/index.tsx
@@ -14,7 +14,7 @@ import { Field, Form } from 'src/components/hook-form';
 import { toast } from 'src/components/snackbar';
 import { useLang } from 'src/hooks/useLang';
 import { paths } from 'src/routes/paths';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 import { Label, LabelColor } from '@/components/label';
 import Box from '@mui/material/Box';
 import { ConfirmDialog } from 'src/components/custom-dialog/confirm-dialog';
@@ -33,8 +33,6 @@ type User = {
   roles: number[];
   email_verified_at: string | null;
 };
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 type FormValues = {
   name: string;

--- a/resources/js/src/pages/dashboard/users/list/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/index.tsx
@@ -36,7 +36,7 @@ import { CustomBreadcrumbs } from 'src/components/custom-breadcrumbs';
 import { FilledInput } from '@mui/material';
 import InputAdornment from '@mui/material/InputAdornment';
 import { ConfirmDialog } from 'src/components/custom-dialog/confirm-dialog';
-import { PageProps as InertiaPageProps } from '@inertiajs/core';
+import type { PageProps } from '@inertiajs/core';
 
 // ----------------------------------------------------------------------
 
@@ -57,8 +57,6 @@ interface Props {
   users: User[];
   roles: Role[];
 }
-
-type PageProps = InertiaPageProps & { csrf_token: string };
 
 const metadata = { title: `Users | Dashboard - ${CONFIG.appName}` };
 

--- a/resources/js/src/types/inertia.d.ts
+++ b/resources/js/src/types/inertia.d.ts
@@ -1,0 +1,22 @@
+import '@inertiajs/core';
+
+type LangValue = string | { [key: string]: LangValue };
+export type LangObject = Record<string, LangValue>;
+
+declare module '@inertiajs/core' {
+  interface PageProps {
+    csrf_token: string;
+    locale: string;
+    lang: LangObject;
+    auth: {
+      user?: {
+        name?: string;
+        email?: string;
+        avatar?: string;
+        role?: string;
+        roles?: string[];
+        permissions?: string[];
+      };
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- augment PageProps to include csrf_token, locale, language and auth user data
- refactor hooks, pages and layout components to use global PageProps via usePage
