### PR TITLE
refactor: split user list into components

### DIFF
--- a/resources/js/src/pages/dashboard/users/list/components/user-delete-dialog/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/components/user-delete-dialog/index.tsx
@@ -1,0 +1,29 @@
+import Button from '@mui/material/Button';
+import { ConfirmDialog } from 'src/components/custom-dialog/confirm-dialog';
+import { useLang } from 'src/hooks/useLang';
+
+// ----------------------------------------------------------------------
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+}
+
+export function UserDeleteDialog({ open, onClose, onDelete }: Props) {
+  const { __ } = useLang();
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onClose={onClose}
+      title={__('pages/users.delete_user')}
+      content={__('pages/users.delete_confirm')}
+      action={
+        <Button color="error" variant="contained" onClick={onDelete}>
+          {__('pages/users.delete')}
+        </Button>
+      }
+    />
+  );
+}

--- a/resources/js/src/pages/dashboard/users/list/components/user-status-tabs/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/components/user-status-tabs/index.tsx
@@ -1,0 +1,43 @@
+import Tabs from '@mui/material/Tabs';
+import Tab from '@mui/material/Tab';
+import { Label } from 'src/components/label';
+import { type SyntheticEvent } from 'react';
+
+// ----------------------------------------------------------------------
+
+export type StatusTab = { value: string; label: string };
+
+interface Props {
+  value: string;
+  tabs: StatusTab[];
+  onChange: (event: SyntheticEvent, value: string) => void;
+  getCount: (value: string) => number;
+}
+
+export function UserStatusTabs({ value, tabs, onChange, getCount }: Props) {
+  return (
+    <Tabs value={value} onChange={onChange} sx={{ px: { md: 2.5 } }}>
+      {tabs.map((tab) => (
+        <Tab
+          key={tab.value}
+          value={tab.value}
+          iconPosition="end"
+          label={tab.label}
+          icon={
+            <Label
+              variant={tab.value === 'all' || tab.value === value ? 'filled' : 'soft'}
+              color={
+                (tab.value === 'active' && 'success') ||
+                (tab.value === 'pending' && 'warning') ||
+                (tab.value === 'banned' && 'error') ||
+                'default'
+              }
+            >
+              {getCount(tab.value)}
+            </Label>
+          }
+        />
+      ))}
+    </Tabs>
+  );
+}

--- a/resources/js/src/pages/dashboard/users/list/components/user-table-filters-result/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/components/user-table-filters-result/index.tsx
@@ -1,0 +1,69 @@
+import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
+import Chip from '@mui/material/Chip';
+import Button from '@mui/material/Button';
+import { Iconify } from 'src/components/iconify';
+import { useLang } from 'src/hooks/useLang';
+import type { Filters, Role } from '../types';
+
+// ----------------------------------------------------------------------
+
+interface Props {
+  filters: Filters;
+  onFilters: (name: keyof Filters, value: string | number | null) => void;
+  onResetFilters: () => void;
+  results: number;
+  roles: Role[];
+}
+
+export function UserTableFiltersResult({
+  filters,
+  onFilters,
+  onResetFilters,
+  results,
+  roles,
+}: Props) {
+  const { __ } = useLang();
+  const { keyword, role, status } = filters;
+  const roleName = role !== null ? roles.find((r) => r.id === role)?.name || '' : '';
+
+  const canReset = keyword || role !== null || status !== 'all';
+  if (!canReset) return null;
+
+  return (
+    <Stack spacing={1} direction="row" alignItems="center" sx={{ p: 2, pt: 0 }}>
+      <Typography variant="body2" sx={{ mr: 1 }}>
+        {__('pages/users.filters.results', { count: results })}
+      </Typography>
+
+      {status !== 'all' && (
+        <Chip
+          label={`${__('pages/users.filters.status')}: ${__('pages/users.tabs.' + status)}`}
+          onDelete={() => onFilters('status', 'all')}
+        />
+      )}
+
+      {role !== null && (
+        <Chip
+          label={`${__('pages/users.filters.role')}: ${__(`pages/users.roles.${roleName.toLowerCase()}`)}`}
+          onDelete={() => onFilters('role', null)}
+        />
+      )}
+
+      {keyword && (
+        <Chip
+          label={`${__('pages/users.filters.keyword')}: ${keyword}`}
+          onDelete={() => onFilters('keyword', '')}
+        />
+      )}
+
+      <Button
+        color="error"
+        startIcon={<Iconify icon="solar:trash-bin-trash-bold" />}
+        onClick={onResetFilters}
+      >
+        {__('pages/users.filters.clear')}
+      </Button>
+    </Stack>
+  );
+}

--- a/resources/js/src/pages/dashboard/users/list/components/user-table-toolbar/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/components/user-table-toolbar/index.tsx
@@ -1,0 +1,70 @@
+import Stack from '@mui/material/Stack';
+import TextField from '@mui/material/TextField';
+import MenuItem from '@mui/material/MenuItem';
+import InputAdornment from '@mui/material/InputAdornment';
+import { Iconify } from 'src/components/iconify';
+import { useLang } from 'src/hooks/useLang';
+import type { Filters, Role } from '../types';
+
+// ----------------------------------------------------------------------
+
+interface Props {
+  filters: Filters;
+  onFilters: (name: keyof Filters, value: string | number | null) => void;
+  roles: Role[];
+}
+
+export function UserTableToolbar({ filters, onFilters, roles }: Props) {
+  const { __ } = useLang();
+
+  return (
+    <Stack spacing={2} direction={{ xs: 'column', sm: 'row' }} sx={{ p: 2 }}>
+      <TextField
+        size="small"
+        variant="filled"
+        hiddenLabel
+        value={filters.keyword}
+        onChange={(e) => onFilters('keyword', e.target.value)}
+        sx={{ width: { xs: 1, sm: 240 } }}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify icon="solar:magnifer-linear" width={24} />
+              </InputAdornment>
+            ),
+          },
+        }}
+      />
+
+      <TextField
+        select
+        size="small"
+        sx={{ minWidth: '100px', width: 'auto' }}
+        hiddenLabel
+        variant="filled"
+        placeholder={__('pages/users.filters.role')}
+        value={filters.role ?? ''}
+        onChange={(e) => onFilters('role', e.target.value === '' ? null : Number(e.target.value))}
+        slotProps={{
+          input: {
+            startAdornment: (
+              <InputAdornment position="start">
+                <Iconify icon="solar:user-id-bold" width={24} />
+              </InputAdornment>
+            ),
+          },
+        }}
+      >
+        {roles.map((role) => {
+          const key = role.name.toLowerCase();
+          return (
+            <MenuItem key={role.id} value={role.id}>
+              {__(`pages/users.roles.${key}`)}
+            </MenuItem>
+          );
+        })}
+      </TextField>
+    </Stack>
+  );
+}

--- a/resources/js/src/pages/dashboard/users/list/types.ts
+++ b/resources/js/src/pages/dashboard/users/list/types.ts
@@ -1,0 +1,12 @@
+export type User = {
+  id: number;
+  name: string;
+  email: string;
+  status: string;
+  created_at: string;
+  roles: number[];
+};
+
+export type Role = { id: number; name: string };
+
+export type Filters = { keyword: string; role: number | null; status: string };


### PR DESCRIPTION
## Summary
- modularize user list page into dedicated components for tabs, filters, toolbar and delete dialog
- centralize shared user list types

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b20bc972e48322abccf1d02fe39806