### PR TITLE
Reorder user table columns and show creation time

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -33,7 +33,7 @@ class UserController extends Controller
                 'name' => $user->name,
                 'email' => $user->email,
                 'status' => $user->status,
-                'created_at' => $user->created_at->toDateString(),
+                'created_at' => $user->created_at->toDateTimeString(),
                 'roles' => $user->roles->pluck('id')->toArray(),
             ]);
 

--- a/resources/js/src/pages/dashboard/users/list/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/index.tsx
@@ -254,8 +254,8 @@ export default function List({ users, roles }: Props) {
                     <TableCell>{__('pages/users.table.name')}</TableCell>
                     <TableCell>{__('pages/users.table.email')}</TableCell>
                     <TableCell>{__('pages/users.table.status')}</TableCell>
-                    <TableCell>{__('pages/users.table.created')}</TableCell>
                     <TableCell>{__('pages/users.table.role')}</TableCell>
+                    <TableCell>{__('pages/users.table.created')}</TableCell>
                     <TableCell align="center">{__('pages/users.table.actions')}</TableCell>
                   </TableRow>
                 </TableHead>
@@ -391,18 +391,6 @@ export default function List({ users, roles }: Props) {
                           )}
                         </TableCell>
                         <TableCell>
-                          <Stack direction="row" spacing={0.5} alignItems="center" sx={hoverSx}>
-                            {user.created_at}
-                            <IconButton
-                              className="action-icons"
-                              size="small"
-                              onClick={() => handleCopy(user.created_at)}
-                            >
-                              <Iconify icon="solar:copy-bold" width={16} />
-                            </IconButton>
-                          </Stack>
-                        </TableCell>
-                        <TableCell>
                           {editing.id === user.id && editing.field === 'roles' ? (
                             <Select
                               autoFocus
@@ -452,6 +440,18 @@ export default function List({ users, roles }: Props) {
                               </IconButton>
                             </Stack>
                           )}
+                        </TableCell>
+                        <TableCell>
+                          <Stack direction="row" spacing={0.5} alignItems="center" sx={hoverSx}>
+                            {user.created_at}
+                            <IconButton
+                              className="action-icons"
+                              size="small"
+                              onClick={() => handleCopy(user.created_at)}
+                            >
+                              <Iconify icon="solar:copy-bold" width={16} />
+                            </IconButton>
+                          </Stack>
                         </TableCell>
                         <TableCell align="center">
                           <Stack direction="row" spacing={1} justifyContent="center">


### PR DESCRIPTION
## Summary
- reorder user list columns to Name, Email, Status, Role, Created, Actions
- include full creation timestamp in users API

## Testing
- `npx prettier -w resources/js/src/pages/dashboard/users/list/index.tsx`
- `php -l app/Http/Controllers/UserController.php`
- `npm test` *(fails: Missing script: "test")*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b219e99d4c8322800427f30f54e10b