### PR TITLE
refactor: use Ziggy for routing

### DIFF
--- a/resources/js/src/layouts/auth-split/layout.tsx
+++ b/resources/js/src/layouts/auth-split/layout.tsx
@@ -94,51 +94,24 @@ export function AuthSplitLayout({
 
   const renderFooter = () => null;
 
-  const renderMain = () => (
-    <MainSection
-      {...slotProps?.main}
-      sx={[
-        (theme) => ({ [theme.breakpoints.up(layoutQuery)]: { flexDirection: 'row', height: '100%' } }),
-        ...(Array.isArray(slotProps?.main?.sx) ? slotProps.main.sx : [slotProps?.main?.sx]),
-      ]}
-    >
-      <AuthSplitSection
-        layoutQuery={layoutQuery}
-        method={CONFIG.auth.method}
-        {...slotProps?.section}
-        methods={[
-          {
-            label: 'Jwt',
-            path: paths.auth.jwt.signIn,
-            icon: `${CONFIG.assetsDir}/assets/icons/platforms/ic-jwt.svg`,
-          },
-          {
-            label: 'Firebase',
-            path: paths.auth.firebase.signIn,
-            icon: `${CONFIG.assetsDir}/assets/icons/platforms/ic-firebase.svg`,
-          },
-          {
-            label: 'Amplify',
-            path: paths.auth.amplify.signIn,
-            icon: `${CONFIG.assetsDir}/assets/icons/platforms/ic-amplify.svg`,
-          },
-          {
-            label: 'Auth0',
-            path: paths.auth.auth0.signIn,
-            icon: `${CONFIG.assetsDir}/assets/icons/platforms/ic-auth0.svg`,
-          },
-          {
-            label: 'Supabase',
-            path: paths.auth.supabase.signIn,
-            icon: `${CONFIG.assetsDir}/assets/icons/platforms/ic-supabase.svg`,
-          },
+    const renderMain = () => (
+      <MainSection
+        {...slotProps?.main}
+        sx={[
+          (theme) => ({ [theme.breakpoints.up(layoutQuery)]: { flexDirection: 'row', height: '100%' } }),
+          ...(Array.isArray(slotProps?.main?.sx) ? slotProps.main.sx : [slotProps?.main?.sx]),
         ]}
-      />
-      <AuthSplitContent layoutQuery={layoutQuery} {...slotProps?.content}>
-        {children}
-      </AuthSplitContent>
-    </MainSection>
-  );
+      >
+        <AuthSplitSection
+          layoutQuery={layoutQuery}
+          method={CONFIG.auth.method}
+          {...slotProps?.section}
+        />
+        <AuthSplitContent layoutQuery={layoutQuery} {...slotProps?.content}>
+          {children}
+        </AuthSplitContent>
+      </MainSection>
+    );
 
   return (
     <LayoutSection

--- a/resources/js/src/layouts/components/nav-upgrade.tsx
+++ b/resources/js/src/layouts/components/nav-upgrade.tsx
@@ -7,7 +7,6 @@ import Button from '@mui/material/Button';
 import Avatar from '@mui/material/Avatar';
 import Typography from '@mui/material/Typography';
 
-import { paths } from 'src/routes/paths';
 
 import { CONFIG } from 'src/global-config';
 
@@ -71,12 +70,12 @@ export function NavUpgrade({ sx, ...other }: BoxProps) {
           </Typography>
         </Box>
 
-        <Button
-          variant="contained"
-          href={paths.minimalStore}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+          <Button
+            variant="contained"
+            href="https://mui.com/store/items/minimal-dashboard/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
           Upgrade to Pro
         </Button>
       </Box>

--- a/resources/js/src/layouts/nav-config-dashboard.tsx
+++ b/resources/js/src/layouts/nav-config-dashboard.tsx
@@ -3,6 +3,7 @@ import type { NavSectionProps } from 'src/components/nav-section';
 import { useMemo } from 'react';
 
 import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 
 import { CONFIG } from 'src/global-config';
 
@@ -71,25 +72,25 @@ export function useNavData(): NavSectionProps['data'] {
         items: [
           {
             title: __('navigation.management.users'),
-            path: paths.users,
+            path: route('users.index'),
             icon: ICONS.user,
             permission: 'USERS_VIEW',
             deepMatch: true,
           },
           {
             title: __('navigation.management.rights'),
-            path: paths.roles,
+            path: route('roles.index'),
             icon: ICONS.lock,
             anyOf: ['ROLES_VIEW', 'PERMISSIONS_VIEW'],
             children: [
               {
                 title: __('navigation.management.roles'),
-                path: paths.roles,
+                path: route('roles.index'),
                 permission: 'ROLES_VIEW',
               },
               {
                 title: __('navigation.management.permissions'),
-                path: paths.permissions,
+                path: route('permissions.index'),
                 permission: 'PERMISSIONS_VIEW',
               },
             ],

--- a/resources/js/src/pages/dashboard/users/create/components/create-user-form/index.tsx
+++ b/resources/js/src/pages/dashboard/users/create/components/create-user-form/index.tsx
@@ -13,7 +13,7 @@ import { Box, IconButton, InputAdornment, Typography } from '@mui/material';
 import { Field, Form } from 'src/components/hook-form';
 import { toast } from 'src/components/snackbar';
 import { useLang } from 'src/hooks/useLang';
-import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 import type { PageProps } from '@inertiajs/core';
 import { useBoolean } from 'minimal-shared/hooks';
 import { Iconify } from '@/components/iconify';
@@ -123,7 +123,7 @@ export function CreateUserForm({ roles }: Props) {
     router.post(route('users.store'), payload, {
       onSuccess: () => {
         toast.success(__('pages/users.create_success'));
-        router.visit(paths.users);
+          router.visit(route('users.index'));
       },
       onError: (errors) => {
         Object.entries(errors).forEach(([field, message]) => {

--- a/resources/js/src/pages/dashboard/users/create/index.tsx
+++ b/resources/js/src/pages/dashboard/users/create/index.tsx
@@ -3,6 +3,7 @@ import { DashboardContent, DashboardLayout } from 'src/layouts/dashboard';
 import { CustomBreadcrumbs } from 'src/components/custom-breadcrumbs';
 import { useLang } from 'src/hooks/useLang';
 import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 import { Can } from 'src/components/Can';
 import { CreateUserForm } from 'src/pages/dashboard/users/create/components/create-user-form';
 
@@ -29,7 +30,7 @@ export default function Create({ roles }: Props) {
               heading={__('pages/users.create_user')}
               links={[
                 { name: __('pages/users.breadcrumbs.dashboard'), href: paths.dashboard.root },
-                { name: __('pages/users.breadcrumbs.users'), href: paths.users },
+                { name: __('pages/users.breadcrumbs.users'), href: route('users.index') },
                 { name: __('pages/users.breadcrumbs.create') },
               ]}
               sx={{ mb: { xs: 3, md: 5 } }}

--- a/resources/js/src/pages/dashboard/users/edit/components/edit-user-form/index.tsx
+++ b/resources/js/src/pages/dashboard/users/edit/components/edit-user-form/index.tsx
@@ -13,7 +13,7 @@ import Typography from '@mui/material/Typography';
 import { Field, Form } from 'src/components/hook-form';
 import { toast } from 'src/components/snackbar';
 import { useLang } from 'src/hooks/useLang';
-import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 import type { PageProps } from '@inertiajs/core';
 import { Label, LabelColor } from '@/components/label';
 import Box from '@mui/material/Box';
@@ -179,7 +179,7 @@ export function EditUserForm({ roles, currentUser }: Props) {
       onSuccess: () => {
         toast.success(__('pages/users.delete_success'));
         setOpenDelete(false);
-        router.visit(paths.users);
+        router.visit(route('users.index'));
       },
       onError: (errors: Record<string, string>) => {
         toast.error(errors.user ?? __('pages/users.delete_error'));

--- a/resources/js/src/pages/dashboard/users/edit/index.tsx
+++ b/resources/js/src/pages/dashboard/users/edit/index.tsx
@@ -3,6 +3,7 @@ import { DashboardContent, DashboardLayout } from 'src/layouts/dashboard';
 import { CustomBreadcrumbs } from 'src/components/custom-breadcrumbs';
 import { useLang } from 'src/hooks/useLang';
 import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 import { Can } from 'src/components/Can';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
@@ -41,12 +42,12 @@ export default function Edit({ user, roles }: Props) {
     {
       label: __('pages/users.edit_tabs.general'),
       icon: <Iconify width={24} icon="solar:user-id-bold" />,
-      href: paths.userEdit(user.id),
+      href: route('users.edit', user.id),
     },
     {
       label: __('pages/users.edit_tabs.security'),
       icon: <Iconify width={24} icon="ic:round-vpn-key" />,
-      href: `${paths.userEdit(user.id)}/change-password`,
+      href: route('users.edit.password', user.id),
     },
   ];
 
@@ -62,7 +63,7 @@ export default function Edit({ user, roles }: Props) {
               heading={__('pages/users.edit_user')}
               links={[
                 { name: __('pages/users.breadcrumbs.dashboard'), href: paths.dashboard.root },
-                { name: __('pages/users.breadcrumbs.users'), href: paths.users },
+                { name: __('pages/users.breadcrumbs.users'), href: route('users.index') },
                 { name: __('pages/users.breadcrumbs.edit') },
               ]}
               sx={{ mb: { xs: 3, md: 5 } }}

--- a/resources/js/src/pages/dashboard/users/list/index.tsx
+++ b/resources/js/src/pages/dashboard/users/list/index.tsx
@@ -6,6 +6,7 @@ import { DashboardContent, DashboardLayout } from 'src/layouts/dashboard';
 import { Iconify } from 'src/components/iconify';
 import { useLang } from 'src/hooks/useLang';
 import { paths } from 'src/routes/paths';
+import { route } from 'src/routes/route';
 import { RouterLink } from 'src/routes/components';
 import { toast } from 'src/components/snackbar';
 import { useAuthz } from 'src/lib/authz';
@@ -260,7 +261,7 @@ export default function List({ users, roles }: Props) {
               <Can permission="USERS_CREATE">
                 <Button
                   component={RouterLink}
-                  href={paths.userCreate}
+                  href={route('users.create')}
                   variant="contained"
                   startIcon={<Iconify icon="mingcute:add-line" />}
                 >
@@ -503,7 +504,7 @@ export default function List({ users, roles }: Props) {
                             {canEdit && (
                               <IconButton
                                 component={RouterLink}
-                                href={paths.userEdit(user.id)}
+                                href={route('users.edit', user.id)}
                                 size="small"
                                 color="primary"
                               >

--- a/resources/js/src/routes/paths.ts
+++ b/resources/js/src/routes/paths.ts
@@ -1,7 +1,6 @@
 // ----------------------------------------------------------------------
 
 const ROOTS = {
-  AUTH: '/auth',
   DASHBOARD: '/dashboard',
 };
 
@@ -14,39 +13,8 @@ export const paths = {
   roles: '/roles',
   permissions: '/permissions',
   faqs: '/faqs',
-  minimalStore: 'https://mui.com/store/items/minimal-dashboard/',
-  // AUTH
-  auth: {
-    amplify: {
-      signIn: `${ROOTS.AUTH}/amplify/sign-in`,
-      verify: `${ROOTS.AUTH}/amplify/verify`,
-      signUp: `${ROOTS.AUTH}/amplify/sign-up`,
-      updatePassword: `${ROOTS.AUTH}/amplify/update-password`,
-      resetPassword: `${ROOTS.AUTH}/amplify/reset-password`,
-    },
-    jwt: {
-      signIn: `${ROOTS.AUTH}/jwt/sign-in`,
-      signUp: `${ROOTS.AUTH}/jwt/sign-up`,
-    },
-    firebase: {
-      signIn: `${ROOTS.AUTH}/firebase/sign-in`,
-      verify: `${ROOTS.AUTH}/firebase/verify`,
-      signUp: `${ROOTS.AUTH}/firebase/sign-up`,
-      resetPassword: `${ROOTS.AUTH}/firebase/reset-password`,
-    },
-    auth0: {
-      signIn: `${ROOTS.AUTH}/auth0/sign-in`,
-    },
-    supabase: {
-      signIn: `${ROOTS.AUTH}/supabase/sign-in`,
-      verify: `${ROOTS.AUTH}/supabase/verify`,
-      signUp: `${ROOTS.AUTH}/supabase/sign-up`,
-      updatePassword: `${ROOTS.AUTH}/supabase/update-password`,
-      resetPassword: `${ROOTS.AUTH}/supabase/reset-password`,
-    },
-  },
   // DASHBOARD
-    dashboard: {
-      root: ROOTS.DASHBOARD,
-    },
-  };
+  dashboard: {
+    root: ROOTS.DASHBOARD,
+  },
+};

--- a/resources/js/src/routes/route.ts
+++ b/resources/js/src/routes/route.ts
@@ -1,0 +1,23 @@
+import Ziggy, { RouteName } from 'src/ziggy';
+
+export function route(name: RouteName, params?: Record<string, any> | string | number, absolute = true) {
+  let uri = Ziggy.routes[name].uri;
+
+  if (params) {
+    const parameters: Record<string, any> =
+      typeof params === 'string' || typeof params === 'number'
+        ? (() => {
+            const key = uri.match(/\{([^}]+)\}/)?.[1];
+            return key ? { [key]: params } : {};
+          })()
+        : params;
+
+    Object.keys(parameters).forEach((key) => {
+      uri = uri.replace(`{${key}}`, encodeURIComponent(String(parameters[key])));
+    });
+  }
+
+  return `/${uri}`;
+}
+
+export default route;

--- a/resources/js/src/ziggy.ts
+++ b/resources/js/src/ziggy.ts
@@ -1,0 +1,30 @@
+export const Ziggy = {
+  url: '',
+  port: null,
+  defaults: {},
+  routes: {
+    'locale.update': { uri: 'locale' },
+    'users.index': { uri: 'users' },
+    'users.create': { uri: 'users/create' },
+    'users.store': { uri: 'users' },
+    'users.edit': { uri: 'users/{user}/edit' },
+    'users.edit.password': { uri: 'users/{user}/edit/change-password' },
+    'users.update': { uri: 'users/{user}' },
+    'users.destroy': { uri: 'users/{user}' },
+    'roles.index': { uri: 'roles' },
+    'roles.store': { uri: 'roles' },
+    'roles.update': { uri: 'roles/{role}' },
+    'roles.destroy': { uri: 'roles/{role}' },
+    'permissions.index': { uri: 'permissions' },
+    'permissions.store': { uri: 'permissions' },
+    'permissions.update': { uri: 'permissions/{permission}' },
+    'permissions.destroy': { uri: 'permissions/{permission}' },
+    login: { uri: 'login' },
+    register: { uri: 'register' },
+    'password.request': { uri: 'forgot-password' },
+  },
+} as const;
+
+export type RouteName = keyof typeof Ziggy.routes;
+
+export default Ziggy;


### PR DESCRIPTION
## Summary
- remove unused auth paths and external link from route paths
- add generated Ziggy route map and helper
- replace hardcoded strings with `route()` across user pages and nav
