### PR TITLE
Use resource classes for users, roles and permissions

### DIFF
--- a/app/Http/Controllers/PermissionController.php
+++ b/app/Http/Controllers/PermissionController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\PermissionResource;
+use App\Http\Resources\RoleResource;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -24,28 +26,13 @@ class PermissionController extends Controller
     {
         $permissions = Permission::with('roles:id,name')
             ->select('id', 'name', 'module', 'created_at')
-            ->get()
-            ->map(fn ($permission) => [
-                'id' => $permission->id,
-                'name' => $permission->name,
-                'module' => $permission->module,
-                'created_at' => $permission->created_at->toDateString(),
-                'roles' => $permission->roles->map(fn ($r) => [
-                    'id' => $r->id,
-                    'name' => $r->name,
-                ]),
-            ]);
+            ->get();
 
-        $roles = Role::select('id', 'name')
-            ->get()
-            ->map(fn ($r) => [
-                'id' => $r->id,
-                'name' => $r->name,
-            ]);
+        $roles = Role::select('id', 'name')->get();
 
         return Inertia::render('dashboard/permissions/list', [
-            'permissions' => $permissions,
-            'roles' => $roles,
+            'permissions' => PermissionResource::collection($permissions),
+            'roles' => RoleResource::collection($roles),
         ]);
     }
 

--- a/app/Http/Controllers/RoleController.php
+++ b/app/Http/Controllers/RoleController.php
@@ -2,6 +2,8 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Resources\PermissionResource;
+use App\Http\Resources\RoleResource;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
@@ -24,27 +26,13 @@ class RoleController extends Controller
     {
         $roles = Role::with('permissions:id,name')
             ->select('id', 'name', 'created_at')
-            ->get()
-            ->map(fn ($role) => [
-                'id' => $role->id,
-                'name' => $role->name,
-                'created_at' => $role->created_at->toDateString(),
-                'permissions' => $role->permissions->map(fn ($p) => [
-                    'id' => $p->id,
-                    'name' => $p->name,
-                ]),
-            ]);
+            ->get();
 
-        $permissions = Permission::select('id', 'name')
-            ->get()
-            ->map(fn ($p) => [
-                'id' => $p->id,
-                'name' => $p->name,
-            ]);
+        $permissions = Permission::select('id', 'name')->get();
 
         return Inertia::render('dashboard/roles/list', [
-            'roles' => $roles,
-            'permissions' => $permissions,
+            'roles' => RoleResource::collection($roles),
+            'permissions' => PermissionResource::collection($permissions),
         ]);
     }
 

--- a/app/Http/Resources/PermissionResource.php
+++ b/app/Http/Resources/PermissionResource.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class PermissionResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'module' => $this->module,
+            'created_at' => $this->created_at?->toDateString(),
+            'roles' => RoleResource::collection($this->whenLoaded('roles')),
+        ];
+    }
+}

--- a/app/Http/Resources/RoleResource.php
+++ b/app/Http/Resources/RoleResource.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class RoleResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'created_at' => $this->created_at?->toDateString(),
+            'permissions' => PermissionResource::collection($this->whenLoaded('permissions')),
+        ];
+    }
+}

--- a/app/Http/Resources/UserResource.php
+++ b/app/Http/Resources/UserResource.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Storage;
+
+class UserResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return array<string, mixed>
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'email' => $this->email,
+            'avatar' => $this->avatar
+                ? (Storage::disk('public')->exists($this->avatar)
+                    ? asset(Storage::url($this->avatar))
+                    : asset($this->avatar))
+                : null,
+            'status' => $this->status,
+            'email_verified_at' => $this->email_verified_at,
+            'created_at' => $this->created_at?->toDateTimeString(),
+            'roles' => $this->roles->pluck('id')->toArray(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add `UserResource`, `RoleResource` and `PermissionResource`
- return resource collections instead of manual maps in controllers
- use single resource instances for individual user responses

## Testing
- ⚠️ `php artisan test` (fails: vendor/autoload.php not found)
- ⚠️ `composer install` (fails: GitHub API rate limit / token required)


------
https://chatgpt.com/codex/tasks/task_e_68b4ccb39ea08322bd9ddfc4763c6f0a