### PR TITLE
fix: guard filter against non-array inputs

### DIFF
--- a/resources/js/src/components/phone-input/list-popover.tsx
+++ b/resources/js/src/components/phone-input/list-popover.tsx
@@ -224,11 +224,13 @@ type ApplyFilterProps = {
 };
 
 function applyFilter({ inputData, query }: ApplyFilterProps) {
-  if (!query) return inputData;
+  const data = Array.isArray(inputData) ? inputData : [];
+
+  if (!query) return data;
 
   const lowerQuery = query.toLowerCase();
 
-  return inputData.filter(({ label, code, phone }) =>
+  return data.filter(({ label, code, phone }) =>
     [label, code, phone].some((field) => field?.toLowerCase().includes(lowerQuery))
   );
 }

--- a/resources/js/src/layouts/components/searchbar/utils.ts
+++ b/resources/js/src/layouts/components/searchbar/utils.ts
@@ -34,7 +34,13 @@ const flattenNavItems = (navItems: NavItem[], parentGroup?: string): OutputItem[
   return flattenedItems;
 };
 
-export function flattenNavSections(navSections: NavSectionProps['data']): OutputItem[] {
+export function flattenNavSections(
+  navSections: NavSectionProps['data'] = []
+): OutputItem[] {
+  if (!Array.isArray(navSections)) {
+    return [];
+  }
+
   return navSections.flatMap((navSection) =>
     flattenNavItems(navSection.items, navSection.subheader)
   );
@@ -48,9 +54,11 @@ type ApplyFilterProps = {
 };
 
 export function applyFilter({ inputData, query }: ApplyFilterProps): OutputItem[] {
-  if (!query) return inputData;
+  const data = Array.isArray(inputData) ? inputData : [];
 
-  return inputData.filter(({ title, path, group }) =>
+  if (!query) return data;
+
+  return data.filter(({ title, path, group }) =>
     [title, path, group].some((field) => field?.toLowerCase().includes(query.toLowerCase()))
   );
 }


### PR DESCRIPTION
## Summary
- handle non-array input gracefully in searchbar and phone input filters

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4d0f7beb48322bd548a90488a3ea3